### PR TITLE
#16 fix infinite loop in dispatcher and enh error handling

### DIFF
--- a/src/Channel/Channel.php
+++ b/src/Channel/Channel.php
@@ -103,7 +103,10 @@ abstract class Channel {
                         $this->doClose();
                     }
                 }
-            } catch(\Exception $exception) {
+                if ($this->open) {
+                    $this->doClose();
+                }
+            } catch (\Exception $exception) {
                 $this->doFail($exception);
             }
         });

--- a/src/Channel/Channel.php
+++ b/src/Channel/Channel.php
@@ -79,28 +79,32 @@ abstract class Channel {
 
     protected function dispatch() {
         asyncCall(function () {
-            while (yield $this->channelMessage->advance()) {
-                $message = $this->channelMessage->getCurrent();
+            try {
+                while (yield $this->channelMessage->advance()) {
+                    $message = $this->channelMessage->getCurrent();
 
-                if ($message instanceof ChannelData) {
-                    $this->dataEmitter->emit($message);
-                }
+                    if ($message instanceof ChannelData) {
+                        $this->dataEmitter->emit($message);
+                    }
 
-                if ($message instanceof ChannelExtendedData) {
-                    $this->dataExtendedEmitter->emit($message);
-                }
+                    if ($message instanceof ChannelExtendedData) {
+                        $this->dataExtendedEmitter->emit($message);
+                    }
 
-                if ($message instanceof ChannelRequest) {
-                    $this->requestEmitter->emit($message);
-                }
+                    if ($message instanceof ChannelRequest) {
+                        $this->requestEmitter->emit($message);
+                    }
 
-                if ($message instanceof ChannelSuccess || $message instanceof ChannelFailure) {
-                    $this->requestResultEmitter->emit($message);
-                }
+                    if ($message instanceof ChannelSuccess || $message instanceof ChannelFailure) {
+                        $this->requestResultEmitter->emit($message);
+                    }
 
-                if ($message instanceof ChannelClose) {
-                    $this->doClose();
+                    if ($message instanceof ChannelClose) {
+                        $this->doClose();
+                    }
                 }
+            } catch(\Exception $exception) {
+                $this->doFail($exception);
             }
         });
     }
@@ -171,6 +175,14 @@ abstract class Channel {
         $this->open = false;
         $this->requestResultEmitter->complete();
         $this->requestEmitter->complete();
+        $this->dataEmitter->complete();
+        $this->dataExtendedEmitter->complete();
+    }
+
+    private function doFail(\Exception $reason) {
+        $this->open = false;
+        $this->requestResultEmitter->fail($reason);
+        $this->requestEmitter->fail($reason);
         $this->dataEmitter->complete();
         $this->dataExtendedEmitter->complete();
     }

--- a/src/Channel/Dispatcher.php
+++ b/src/Channel/Dispatcher.php
@@ -37,7 +37,7 @@ class Dispatcher {
             while ($this->running) {
                 $message = yield $this->handler->read();
 
-                if($message === null) {
+                if ($message === null) {
                     $this->doFail(new ChannelException('SSH connection was closed by remote server'));
                 }
 
@@ -72,8 +72,7 @@ class Dispatcher {
         });
     }
 
-    private function doFail(\Throwable $reason)
-    {
+    private function doFail(\Throwable $reason) {
         $this->stop();
         foreach ($this->channelsEmitter as $channelId => $emitter) {
             $emitter->fail($reason);

--- a/src/Channel/Dispatcher.php
+++ b/src/Channel/Dispatcher.php
@@ -37,6 +37,10 @@ class Dispatcher {
             while ($this->running) {
                 $message = yield $this->handler->read();
 
+                if($message === null) {
+                    $this->doFail(new ChannelException('SSH connection was closed by remote server'));
+                }
+
                 if (!$message instanceof Message) {
                     continue;
                 }
@@ -66,6 +70,16 @@ class Dispatcher {
                 }
             }
         });
+    }
+
+    private function doFail(\Throwable $reason)
+    {
+        $this->stop();
+        foreach ($this->channelsEmitter as $channelId => $emitter) {
+            $emitter->fail($reason);
+
+            unset($this->channelsEmitter[$channelId]);
+        }
     }
 
     public function stop() {

--- a/src/Process.php
+++ b/src/Process.php
@@ -66,22 +66,22 @@ class Process {
         $this->resolved = new Deferred();
 
         return call(function () {
-        	try {
-				if (!$this->open) {
-					yield $this->session->open();
+            try {
+                if (!$this->open) {
+                    yield $this->session->open();
 
-					$this->open = true;
-				}
+                    $this->open = true;
+                }
 
-				foreach ($this->env as $key => $value) {
-					yield $this->session->env($key, $value);
-				}
+                foreach ($this->env as $key => $value) {
+                    yield $this->session->env($key, $value);
+                }
 
-				yield $this->session->exec($this->command);
-			} catch(\Exception $exception) {
-        		$this->resolved = null;
-        		throw $exception;
-			}
+                yield $this->session->exec($this->command);
+            } catch (\Exception $exception) {
+                $this->resolved = null;
+                throw $exception;
+            }
         });
     }
 
@@ -140,10 +140,18 @@ class Process {
                         $resolved->resolve($message->code);
                     }
                 }
+                // some servers does not send exit status
+                if ($this->resolved) {
+                    $this->resolved->resolve(false);
+                    $this->exitCode = false;
+                    $this->resolved = null;
+                }
             } catch (\Exception $exception) {
-                $resolved = $this->resolved;
-                $this->resolved = null;
-                $resolved->fail($exception);
+                if ($this->resolved) {
+                    $resolved = $this->resolved;
+                    $this->resolved = null;
+                    $resolved->fail($exception);
+                }
             }
         });
     }

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -72,15 +72,21 @@ class Shell {
         $this->exitCode = null;
 
         return call(function () use ($columns, $rows, $width, $height) {
-            yield $this->session->open();
+			try {
+				yield $this->session->open();
 
-            foreach ($this->env as $key => $value) {
-                yield $this->session->env($key, $value, true);
-            }
+				foreach ($this->env as $key => $value) {
+					yield $this->session->env($key, $value, true);
+				}
 
-            yield $this->session->pty($columns, $rows, $width, $height);
-            yield $this->session->shell();
-        });
+				yield $this->session->pty($columns, $rows, $width, $height);
+				yield $this->session->shell();
+			} catch (\Exception $exception) {
+				$this->resolved = null;
+				throw $exception;
+			}
+
+		});
     }
 
     public function changeWindowSize(int $columns = 80, int $rows = 24, int $width = 800, int $height = 600) {
@@ -126,18 +132,23 @@ class Shell {
     private function handleRequests() {
         asyncCall(function () {
             $requestIterator = $this->session->getRequestEmitter()->iterate();
+            try {
+                while (yield $requestIterator->advance()) {
+                    $message = $requestIterator->getCurrent();
 
-            while (yield $requestIterator->advance()) {
-                $message = $requestIterator->getCurrent();
+                    if ($message instanceof ChannelRequestExitStatus) {
+                        $resolved = $this->resolved;
+                        $this->resolved = null;
+                        $this->exitCode = $message->code;
+                        $resolved->resolve($message->code);
 
-                if ($message instanceof ChannelRequestExitStatus) {
-                    $resolved = $this->resolved;
-                    $this->resolved = null;
-                    $this->exitCode = $message->code;
-                    $resolved->resolve($message->code);
-
-                    break;
+                        break;
+                    }
                 }
+            } catch (\Exception $exception) {
+                $resolved = $this->resolved;
+                $this->resolved = null;
+                $resolved->fail($exception);
             }
         });
     }

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -72,21 +72,20 @@ class Shell {
         $this->exitCode = null;
 
         return call(function () use ($columns, $rows, $width, $height) {
-			try {
-				yield $this->session->open();
+            try {
+                yield $this->session->open();
 
-				foreach ($this->env as $key => $value) {
-					yield $this->session->env($key, $value, true);
-				}
+                foreach ($this->env as $key => $value) {
+                    yield $this->session->env($key, $value, true);
+                }
 
-				yield $this->session->pty($columns, $rows, $width, $height);
-				yield $this->session->shell();
-			} catch (\Exception $exception) {
-				$this->resolved = null;
-				throw $exception;
-			}
-
-		});
+                yield $this->session->pty($columns, $rows, $width, $height);
+                yield $this->session->shell();
+            } catch (\Exception $exception) {
+                $this->resolved = null;
+                throw $exception;
+            }
+        });
     }
 
     public function changeWindowSize(int $columns = 80, int $rows = 24, int $width = 800, int $height = 600) {
@@ -145,10 +144,18 @@ class Shell {
                         break;
                     }
                 }
+                // some servers does not send exit status
+                if ($this->resolved) {
+                    $this->resolved->resolve(false);
+                    $this->exitCode = false;
+                    $this->resolved = null;
+                }
             } catch (\Exception $exception) {
-                $resolved = $this->resolved;
-                $this->resolved = null;
-                $resolved->fail($exception);
+                if ($this->resolved) {
+                    $resolved = $this->resolved;
+                    $this->resolved = null;
+                    $resolved->fail($exception);
+                }
             }
         });
     }

--- a/tests/Channel/SessionTest.php
+++ b/tests/Channel/SessionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Amp\Ssh\Tests\Channel;
+
+use Amp\Loop;
+use Amp\Ssh\Authentication\UsernamePassword;
+use Amp\Ssh\Channel\ChannelException;
+use Amp\Ssh\Channel\Session;
+use function Amp\Ssh\connect;
+use Amp\Ssh\SshResource;
+use Amp\Ssh\Tests\NetworkHelper;
+use PHPUnit\Framework\TestCase;
+
+class SessionTest extends TestCase {
+    protected function getSsh() {
+        return connect('127.0.0.1:2222', new UsernamePassword('root', 'root'));
+    }
+
+    /**
+     * if connection closed by server then fail dispatcher and all opened request emitters.
+     */
+    public function testRequestEmitterFailedAfterDisconnect() {
+        $this->expectException(ChannelException::class);
+        Loop::run(function () {
+            $connection = yield $this->getSsh();
+            /** @var Session $session */
+            $session = $connection->createSession();
+            yield $session->open();
+            NetworkHelper::disconnect($connection);
+            $iterator = $session->getRequestEmitter()->iterate();
+            yield $iterator->advance();
+        });
+    }
+
+    /**
+     * if connection  closed by server then fail dispatcher and close all opened data emitters.
+     */
+    public function testDataEmitterClosedAfterDisconnect() {
+        Loop::run(function () {
+            $connection = yield $this->getSsh();
+            /** @var Session $session */
+            $session = $connection->createSession();
+            yield $session->open();
+            NetworkHelper::disconnect($connection);
+
+            $iterator = $session->getDataEmitter()->iterate();
+            $hasNext = yield $iterator->advance();
+            $this->assertFalse($hasNext);
+
+            $iterator = $session->getDataExtendedEmitter()->iterate();
+            $hasNext = yield $iterator->advance();
+            $this->assertFalse($hasNext);
+        });
+    }
+
+    /**
+     * if dispatcher closed then all opened channels from client must stop.
+     */
+    public function testSessionClosedAfterConnectionClose() {
+        Loop::run(function () {
+            /** @var SshResource $connection */
+            $connection = yield $this->getSsh();
+            $session = $connection->createSession();
+            yield $session->open();
+            $connection->close();
+
+            $iterator = $session->getRequestEmitter()->iterate();
+
+            $hasNext = yield $iterator->advance();
+            $this->assertFalse($hasNext);
+        });
+    }
+}

--- a/tests/NetworkHelper.php
+++ b/tests/NetworkHelper.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Amp\Ssh\Tests;
+
+use Amp\Ssh\SshResource;
+
+class NetworkHelper {
+    /**
+     * Simulate disconnect from server.
+     * @param SshResource $sshResource
+     */
+    public static function disconnect(SshResource $sshResource) {
+        $reflection = new \ReflectionObject($sshResource);
+        $property = $reflection->getProperty('handler');
+        $property->setAccessible(true);
+        $handler = $property->getValue($sshResource);
+        $handler->close();
+    }
+}

--- a/tests/ProcessTest.php
+++ b/tests/ProcessTest.php
@@ -5,9 +5,11 @@ namespace Amp\Ssh\Tests;
 use function Amp\call;
 use Amp\Loop;
 use Amp\Ssh\Authentication\UsernamePassword;
+use Amp\Ssh\Channel\ChannelException;
 use Amp\Ssh\Channel\SessionEnvException;
 use function Amp\Ssh\connect;
 use Amp\Ssh\Process;
+use Amp\Ssh\SshResource;
 use Amp\Ssh\StatusError;
 use PHPUnit\Framework\TestCase;
 
@@ -183,6 +185,48 @@ class ProcessTest extends TestCase {
             self::assertEquals(0, $exitCode);
 
             yield $ssh->close();
+        });
+    }
+
+    /**
+     * If connection closed by server and process started then fail with channel error.
+     */
+    public function testProcessFailOnDisconnect() {
+        $this->expectException(ChannelException::class);
+        Loop::run(function () {
+            /** @var SshResource $ssh */
+            $ssh = yield $this->getSsh();
+
+            $process = new Process($ssh, 'sleep 10; echo test;');
+
+            yield $process->start();
+            self::assertTrue($process->isRunning());
+            Loop::defer(function () use ($ssh) {
+                NetworkHelper::disconnect($ssh);
+            });
+            yield $process->join();
+        });
+    }
+
+    /**
+     * If channel closed then join must resolve with false exitCode
+     * Some implementations doesn't send exit code.
+     * In that cases false must be used.
+     */
+    public function testProcessFinishWithFalseOnChannelClose() {
+        Loop::run(function () {
+            /** @var SshResource $ssh */
+            $ssh = yield $this->getSsh();
+
+            $process = new Process($ssh, 'sleep 10; echo test;');
+
+            yield $process->start();
+            self::assertTrue($process->isRunning());
+            Loop::defer(function () use ($ssh) {
+                $ssh->close();
+            });
+            $exitCode = yield $process->join();
+            self::assertFalse($exitCode, false);
         });
     }
 }


### PR DESCRIPTION
if opened connection closed then dispatcher fail all channels
if opened channel failed then it fail all emitters
if process start/shell start failed then throw error and prevent joining.
if process run/shell run failed because of error then resolve join promise with that error.