### PR TITLE
Fix #22 Properly close channels

### DIFF
--- a/src/Channel/Channel.php
+++ b/src/Channel/Channel.php
@@ -100,7 +100,12 @@ abstract class Channel {
                     }
 
                     if ($message instanceof ChannelClose) {
-                        $this->doClose();
+                        if($this->open) {
+                            yield $this->close();
+                        }
+                        else {
+                            $this->doClose();
+                        }
                     }
                 }
                 if ($this->open) {
@@ -125,6 +130,7 @@ abstract class Channel {
 
             if ($openResult instanceof ChannelOpenConfirmation) {
                 $this->open = true;
+                $this->channelId = $openResult->senderChannel;
                 $this->dispatch();
 
                 return true;


### PR DESCRIPTION
Fix for #22 
There were two bugs:
* The client must ack the SSH_MSG_CHANNEL_CLOSE message (RFC4254 section 5.3)
* The client was using it's own channel ID as if the server was using the same one. The client must read the sender channel when receiving a SSH_MSG_CHANNEL_OPEN_CONFIRMATION message (RFC4254 section 5.1)